### PR TITLE
feat(ecs): Add deployment circuit breaker with alerting to Retool ser…

### DIFF
--- a/modules/aws_ecs/alerting.tf
+++ b/modules/aws_ecs/alerting.tf
@@ -1,0 +1,233 @@
+data "aws_sns_topic" "platform_sns_topic" {
+  name = "prod-platform-sns-topic-curai"
+}
+
+# --- retool (main) ---
+
+resource "aws_cloudwatch_event_rule" "retool_deployment_failure" {
+  name        = "${var.deployment_name}-retool-deployment-failure"
+  description = "${var.deployment_name} retool deployment failure event rule"
+
+  event_pattern = jsonencode({
+    source : ["aws.ecs"],
+    detail-type : ["ECS Deployment State Change"],
+    resources : [aws_ecs_service.retool.id],
+    detail : {
+      "eventType" : ["ERROR"],
+      "eventName" : ["SERVICE_DEPLOYMENT_FAILED"],
+      "clusterArn" : [aws_ecs_cluster.this.arn]
+    }
+  })
+}
+
+resource "aws_cloudwatch_metric_alarm" "retool_deployment_failure" {
+  alarm_name          = "${var.deployment_name}-retool-deployment-failure-alarm"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "MatchedEvents"
+  namespace           = "AWS/Events"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 0
+  alarm_description   = "${var.deployment_name} retool deployment failed"
+  treat_missing_data  = "notBreaching"
+  actions_enabled     = true
+  alarm_actions       = [data.aws_sns_topic.platform_sns_topic.arn]
+
+  dimensions = {
+    RuleName = aws_cloudwatch_event_rule.retool_deployment_failure.name
+  }
+}
+
+# --- jobs_runner ---
+
+resource "aws_cloudwatch_event_rule" "jobs_runner_deployment_failure" {
+  name        = "${var.deployment_name}-jobs-runner-deployment-failure"
+  description = "${var.deployment_name} jobs runner deployment failure event rule"
+
+  event_pattern = jsonencode({
+    source : ["aws.ecs"],
+    detail-type : ["ECS Deployment State Change"],
+    resources : [aws_ecs_service.jobs_runner.id],
+    detail : {
+      "eventType" : ["ERROR"],
+      "eventName" : ["SERVICE_DEPLOYMENT_FAILED"],
+      "clusterArn" : [aws_ecs_cluster.this.arn]
+    }
+  })
+}
+
+resource "aws_cloudwatch_metric_alarm" "jobs_runner_deployment_failure" {
+  alarm_name          = "${var.deployment_name}-jobs-runner-deployment-failure-alarm"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "MatchedEvents"
+  namespace           = "AWS/Events"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 0
+  alarm_description   = "${var.deployment_name} jobs runner deployment failed"
+  treat_missing_data  = "notBreaching"
+  actions_enabled     = true
+  alarm_actions       = [data.aws_sns_topic.platform_sns_topic.arn]
+
+  dimensions = {
+    RuleName = aws_cloudwatch_event_rule.jobs_runner_deployment_failure.name
+  }
+}
+
+# --- workflows_backend ---
+
+resource "aws_cloudwatch_event_rule" "workflows_backend_deployment_failure" {
+  count       = var.workflows_enabled ? 1 : 0
+  name        = "${var.deployment_name}-workflows-backend-deployment-failure"
+  description = "${var.deployment_name} workflows backend deployment failure event rule"
+
+  event_pattern = jsonencode({
+    source : ["aws.ecs"],
+    detail-type : ["ECS Deployment State Change"],
+    resources : [aws_ecs_service.workflows_backend[0].id],
+    detail : {
+      "eventType" : ["ERROR"],
+      "eventName" : ["SERVICE_DEPLOYMENT_FAILED"],
+      "clusterArn" : [aws_ecs_cluster.this.arn]
+    }
+  })
+}
+
+resource "aws_cloudwatch_metric_alarm" "workflows_backend_deployment_failure" {
+  count               = var.workflows_enabled ? 1 : 0
+  alarm_name          = "${var.deployment_name}-workflows-backend-deployment-failure-alarm"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "MatchedEvents"
+  namespace           = "AWS/Events"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 0
+  alarm_description   = "${var.deployment_name} workflows backend deployment failed"
+  treat_missing_data  = "notBreaching"
+  actions_enabled     = true
+  alarm_actions       = [data.aws_sns_topic.platform_sns_topic.arn]
+
+  dimensions = {
+    RuleName = aws_cloudwatch_event_rule.workflows_backend_deployment_failure[0].name
+  }
+}
+
+# --- workflows_worker ---
+
+resource "aws_cloudwatch_event_rule" "workflows_worker_deployment_failure" {
+  count       = var.workflows_enabled ? 1 : 0
+  name        = "${var.deployment_name}-workflows-worker-deployment-failure"
+  description = "${var.deployment_name} workflows worker deployment failure event rule"
+
+  event_pattern = jsonencode({
+    source : ["aws.ecs"],
+    detail-type : ["ECS Deployment State Change"],
+    resources : [aws_ecs_service.workflows_worker[0].id],
+    detail : {
+      "eventType" : ["ERROR"],
+      "eventName" : ["SERVICE_DEPLOYMENT_FAILED"],
+      "clusterArn" : [aws_ecs_cluster.this.arn]
+    }
+  })
+}
+
+resource "aws_cloudwatch_metric_alarm" "workflows_worker_deployment_failure" {
+  count               = var.workflows_enabled ? 1 : 0
+  alarm_name          = "${var.deployment_name}-workflows-worker-deployment-failure-alarm"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "MatchedEvents"
+  namespace           = "AWS/Events"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 0
+  alarm_description   = "${var.deployment_name} workflows worker deployment failed"
+  treat_missing_data  = "notBreaching"
+  actions_enabled     = true
+  alarm_actions       = [data.aws_sns_topic.platform_sns_topic.arn]
+
+  dimensions = {
+    RuleName = aws_cloudwatch_event_rule.workflows_worker_deployment_failure[0].name
+  }
+}
+
+# --- code_executor ---
+
+resource "aws_cloudwatch_event_rule" "code_executor_deployment_failure" {
+  count       = var.code_executor_enabled ? 1 : 0
+  name        = "${var.deployment_name}-code-executor-deployment-failure"
+  description = "${var.deployment_name} code executor deployment failure event rule"
+
+  event_pattern = jsonencode({
+    source : ["aws.ecs"],
+    detail-type : ["ECS Deployment State Change"],
+    resources : [aws_ecs_service.code_executor[0].id],
+    detail : {
+      "eventType" : ["ERROR"],
+      "eventName" : ["SERVICE_DEPLOYMENT_FAILED"],
+      "clusterArn" : [aws_ecs_cluster.this.arn]
+    }
+  })
+}
+
+resource "aws_cloudwatch_metric_alarm" "code_executor_deployment_failure" {
+  count               = var.code_executor_enabled ? 1 : 0
+  alarm_name          = "${var.deployment_name}-code-executor-deployment-failure-alarm"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "MatchedEvents"
+  namespace           = "AWS/Events"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 0
+  alarm_description   = "${var.deployment_name} code executor deployment failed"
+  treat_missing_data  = "notBreaching"
+  actions_enabled     = true
+  alarm_actions       = [data.aws_sns_topic.platform_sns_topic.arn]
+
+  dimensions = {
+    RuleName = aws_cloudwatch_event_rule.code_executor_deployment_failure[0].name
+  }
+}
+
+# --- telemetry ---
+
+resource "aws_cloudwatch_event_rule" "telemetry_deployment_failure" {
+  count       = var.telemetry_enabled ? 1 : 0
+  name        = "${var.deployment_name}-telemetry-deployment-failure"
+  description = "${var.deployment_name} telemetry deployment failure event rule"
+
+  event_pattern = jsonencode({
+    source : ["aws.ecs"],
+    detail-type : ["ECS Deployment State Change"],
+    resources : [aws_ecs_service.telemetry[0].id],
+    detail : {
+      "eventType" : ["ERROR"],
+      "eventName" : ["SERVICE_DEPLOYMENT_FAILED"],
+      "clusterArn" : [aws_ecs_cluster.this.arn]
+    }
+  })
+}
+
+resource "aws_cloudwatch_metric_alarm" "telemetry_deployment_failure" {
+  count               = var.telemetry_enabled ? 1 : 0
+  alarm_name          = "${var.deployment_name}-telemetry-deployment-failure-alarm"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "MatchedEvents"
+  namespace           = "AWS/Events"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 0
+  alarm_description   = "${var.deployment_name} telemetry deployment failed"
+  treat_missing_data  = "notBreaching"
+  actions_enabled     = true
+  alarm_actions       = [data.aws_sns_topic.platform_sns_topic.arn]
+
+  dimensions = {
+    RuleName = aws_cloudwatch_event_rule.telemetry_deployment_failure[0].name
+  }
+}

--- a/modules/aws_ecs/alerting.tf
+++ b/modules/aws_ecs/alerting.tf
@@ -1,17 +1,35 @@
+locals {
+  ecs_services = merge(
+    {
+      retool      = aws_ecs_service.retool.id
+      jobs-runner = aws_ecs_service.jobs_runner.id
+    },
+    var.workflows_enabled ? {
+      workflows-backend = aws_ecs_service.workflows_backend[0].id
+      workflows-worker  = aws_ecs_service.workflows_worker[0].id
+    } : {},
+    var.code_executor_enabled ? {
+      code-executor = aws_ecs_service.code_executor[0].id
+    } : {},
+    var.telemetry_enabled ? {
+      telemetry = aws_ecs_service.telemetry[0].id
+    } : {},
+  )
+}
+
 data "aws_sns_topic" "platform_sns_topic" {
   name = "prod-platform-sns-topic-curai"
 }
 
-# --- retool (main) ---
-
-resource "aws_cloudwatch_event_rule" "retool_deployment_failure" {
-  name        = "${var.deployment_name}-retool-deployment-failure"
-  description = "${var.deployment_name} retool deployment failure event rule"
+resource "aws_cloudwatch_event_rule" "deployment_failure" {
+  for_each    = local.ecs_services
+  name        = "${var.deployment_name}-${each.key}-deployment-failure"
+  description = "${var.deployment_name} ${each.key} deployment failure event rule"
 
   event_pattern = jsonencode({
     source : ["aws.ecs"],
     detail-type : ["ECS Deployment State Change"],
-    resources : [aws_ecs_service.retool.id],
+    resources : [each.value],
     detail : {
       "eventType" : ["ERROR"],
       "eventName" : ["SERVICE_DEPLOYMENT_FAILED"],
@@ -20,8 +38,9 @@ resource "aws_cloudwatch_event_rule" "retool_deployment_failure" {
   })
 }
 
-resource "aws_cloudwatch_metric_alarm" "retool_deployment_failure" {
-  alarm_name          = "${var.deployment_name}-retool-deployment-failure-alarm"
+resource "aws_cloudwatch_metric_alarm" "deployment_failure" {
+  for_each            = local.ecs_services
+  alarm_name          = "${var.deployment_name}-${each.key}-deployment-failure-alarm"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
   metric_name         = "MatchedEvents"
@@ -29,205 +48,12 @@ resource "aws_cloudwatch_metric_alarm" "retool_deployment_failure" {
   period              = 300
   statistic           = "Sum"
   threshold           = 0
-  alarm_description   = "${var.deployment_name} retool deployment failed"
+  alarm_description   = "${var.deployment_name} ${each.key} deployment failed"
   treat_missing_data  = "notBreaching"
   actions_enabled     = true
   alarm_actions       = [data.aws_sns_topic.platform_sns_topic.arn]
 
   dimensions = {
-    RuleName = aws_cloudwatch_event_rule.retool_deployment_failure.name
-  }
-}
-
-# --- jobs_runner ---
-
-resource "aws_cloudwatch_event_rule" "jobs_runner_deployment_failure" {
-  name        = "${var.deployment_name}-jobs-runner-deployment-failure"
-  description = "${var.deployment_name} jobs runner deployment failure event rule"
-
-  event_pattern = jsonencode({
-    source : ["aws.ecs"],
-    detail-type : ["ECS Deployment State Change"],
-    resources : [aws_ecs_service.jobs_runner.id],
-    detail : {
-      "eventType" : ["ERROR"],
-      "eventName" : ["SERVICE_DEPLOYMENT_FAILED"],
-      "clusterArn" : [aws_ecs_cluster.this.arn]
-    }
-  })
-}
-
-resource "aws_cloudwatch_metric_alarm" "jobs_runner_deployment_failure" {
-  alarm_name          = "${var.deployment_name}-jobs-runner-deployment-failure-alarm"
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 1
-  metric_name         = "MatchedEvents"
-  namespace           = "AWS/Events"
-  period              = 300
-  statistic           = "Sum"
-  threshold           = 0
-  alarm_description   = "${var.deployment_name} jobs runner deployment failed"
-  treat_missing_data  = "notBreaching"
-  actions_enabled     = true
-  alarm_actions       = [data.aws_sns_topic.platform_sns_topic.arn]
-
-  dimensions = {
-    RuleName = aws_cloudwatch_event_rule.jobs_runner_deployment_failure.name
-  }
-}
-
-# --- workflows_backend ---
-
-resource "aws_cloudwatch_event_rule" "workflows_backend_deployment_failure" {
-  count       = var.workflows_enabled ? 1 : 0
-  name        = "${var.deployment_name}-workflows-backend-deployment-failure"
-  description = "${var.deployment_name} workflows backend deployment failure event rule"
-
-  event_pattern = jsonencode({
-    source : ["aws.ecs"],
-    detail-type : ["ECS Deployment State Change"],
-    resources : [aws_ecs_service.workflows_backend[0].id],
-    detail : {
-      "eventType" : ["ERROR"],
-      "eventName" : ["SERVICE_DEPLOYMENT_FAILED"],
-      "clusterArn" : [aws_ecs_cluster.this.arn]
-    }
-  })
-}
-
-resource "aws_cloudwatch_metric_alarm" "workflows_backend_deployment_failure" {
-  count               = var.workflows_enabled ? 1 : 0
-  alarm_name          = "${var.deployment_name}-workflows-backend-deployment-failure-alarm"
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 1
-  metric_name         = "MatchedEvents"
-  namespace           = "AWS/Events"
-  period              = 300
-  statistic           = "Sum"
-  threshold           = 0
-  alarm_description   = "${var.deployment_name} workflows backend deployment failed"
-  treat_missing_data  = "notBreaching"
-  actions_enabled     = true
-  alarm_actions       = [data.aws_sns_topic.platform_sns_topic.arn]
-
-  dimensions = {
-    RuleName = aws_cloudwatch_event_rule.workflows_backend_deployment_failure[0].name
-  }
-}
-
-# --- workflows_worker ---
-
-resource "aws_cloudwatch_event_rule" "workflows_worker_deployment_failure" {
-  count       = var.workflows_enabled ? 1 : 0
-  name        = "${var.deployment_name}-workflows-worker-deployment-failure"
-  description = "${var.deployment_name} workflows worker deployment failure event rule"
-
-  event_pattern = jsonencode({
-    source : ["aws.ecs"],
-    detail-type : ["ECS Deployment State Change"],
-    resources : [aws_ecs_service.workflows_worker[0].id],
-    detail : {
-      "eventType" : ["ERROR"],
-      "eventName" : ["SERVICE_DEPLOYMENT_FAILED"],
-      "clusterArn" : [aws_ecs_cluster.this.arn]
-    }
-  })
-}
-
-resource "aws_cloudwatch_metric_alarm" "workflows_worker_deployment_failure" {
-  count               = var.workflows_enabled ? 1 : 0
-  alarm_name          = "${var.deployment_name}-workflows-worker-deployment-failure-alarm"
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 1
-  metric_name         = "MatchedEvents"
-  namespace           = "AWS/Events"
-  period              = 300
-  statistic           = "Sum"
-  threshold           = 0
-  alarm_description   = "${var.deployment_name} workflows worker deployment failed"
-  treat_missing_data  = "notBreaching"
-  actions_enabled     = true
-  alarm_actions       = [data.aws_sns_topic.platform_sns_topic.arn]
-
-  dimensions = {
-    RuleName = aws_cloudwatch_event_rule.workflows_worker_deployment_failure[0].name
-  }
-}
-
-# --- code_executor ---
-
-resource "aws_cloudwatch_event_rule" "code_executor_deployment_failure" {
-  count       = var.code_executor_enabled ? 1 : 0
-  name        = "${var.deployment_name}-code-executor-deployment-failure"
-  description = "${var.deployment_name} code executor deployment failure event rule"
-
-  event_pattern = jsonencode({
-    source : ["aws.ecs"],
-    detail-type : ["ECS Deployment State Change"],
-    resources : [aws_ecs_service.code_executor[0].id],
-    detail : {
-      "eventType" : ["ERROR"],
-      "eventName" : ["SERVICE_DEPLOYMENT_FAILED"],
-      "clusterArn" : [aws_ecs_cluster.this.arn]
-    }
-  })
-}
-
-resource "aws_cloudwatch_metric_alarm" "code_executor_deployment_failure" {
-  count               = var.code_executor_enabled ? 1 : 0
-  alarm_name          = "${var.deployment_name}-code-executor-deployment-failure-alarm"
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 1
-  metric_name         = "MatchedEvents"
-  namespace           = "AWS/Events"
-  period              = 300
-  statistic           = "Sum"
-  threshold           = 0
-  alarm_description   = "${var.deployment_name} code executor deployment failed"
-  treat_missing_data  = "notBreaching"
-  actions_enabled     = true
-  alarm_actions       = [data.aws_sns_topic.platform_sns_topic.arn]
-
-  dimensions = {
-    RuleName = aws_cloudwatch_event_rule.code_executor_deployment_failure[0].name
-  }
-}
-
-# --- telemetry ---
-
-resource "aws_cloudwatch_event_rule" "telemetry_deployment_failure" {
-  count       = var.telemetry_enabled ? 1 : 0
-  name        = "${var.deployment_name}-telemetry-deployment-failure"
-  description = "${var.deployment_name} telemetry deployment failure event rule"
-
-  event_pattern = jsonencode({
-    source : ["aws.ecs"],
-    detail-type : ["ECS Deployment State Change"],
-    resources : [aws_ecs_service.telemetry[0].id],
-    detail : {
-      "eventType" : ["ERROR"],
-      "eventName" : ["SERVICE_DEPLOYMENT_FAILED"],
-      "clusterArn" : [aws_ecs_cluster.this.arn]
-    }
-  })
-}
-
-resource "aws_cloudwatch_metric_alarm" "telemetry_deployment_failure" {
-  count               = var.telemetry_enabled ? 1 : 0
-  alarm_name          = "${var.deployment_name}-telemetry-deployment-failure-alarm"
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 1
-  metric_name         = "MatchedEvents"
-  namespace           = "AWS/Events"
-  period              = 300
-  statistic           = "Sum"
-  threshold           = 0
-  alarm_description   = "${var.deployment_name} telemetry deployment failed"
-  treat_missing_data  = "notBreaching"
-  actions_enabled     = true
-  alarm_actions       = [data.aws_sns_topic.platform_sns_topic.arn]
-
-  dimensions = {
-    RuleName = aws_cloudwatch_event_rule.telemetry_deployment_failure[0].name
+    RuleName = aws_cloudwatch_event_rule.deployment_failure[each.key].name
   }
 }

--- a/modules/aws_ecs/main.tf
+++ b/modules/aws_ecs/main.tf
@@ -62,6 +62,11 @@ resource "aws_ecs_service" "retool" {
   propagate_tags                     = var.task_propagate_tags
   enable_execute_command             = var.enable_execute_command
 
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
   load_balancer {
     target_group_arn = aws_lb_target_group.this.arn
     container_name   = "retool"
@@ -96,6 +101,11 @@ resource "aws_ecs_service" "jobs_runner" {
   propagate_tags         = var.task_propagate_tags
   enable_execute_command = var.enable_execute_command
 
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
   # Need to explictly set this in aws_ecs_service to avoid destructive behavior: https://github.com/hashicorp/terraform-provider-aws/issues/22823
   capacity_provider_strategy {
     base              = 1
@@ -124,6 +134,11 @@ resource "aws_ecs_service" "workflows_backend" {
   task_definition        = aws_ecs_task_definition.retool_workflows_backend[0].arn
   propagate_tags         = var.task_propagate_tags
   enable_execute_command = var.enable_execute_command
+
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
 
   # Need to explictly set this in aws_ecs_service to avoid destructive behavior: https://github.com/hashicorp/terraform-provider-aws/issues/22823
   capacity_provider_strategy {
@@ -158,6 +173,11 @@ resource "aws_ecs_service" "workflows_worker" {
   propagate_tags         = var.task_propagate_tags
   enable_execute_command = var.enable_execute_command
 
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
   # Need to explictly set this in aws_ecs_service to avoid destructive behavior: https://github.com/hashicorp/terraform-provider-aws/issues/22823
   capacity_provider_strategy {
     base              = 1
@@ -185,6 +205,11 @@ resource "aws_ecs_service" "code_executor" {
   desired_count          = 1
   task_definition        = aws_ecs_task_definition.retool_code_executor[0].arn
   enable_execute_command = var.enable_execute_command
+
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
 
   # Need to explictly set this in aws_ecs_service to avoid destructive behavior: https://github.com/hashicorp/terraform-provider-aws/issues/22823
   capacity_provider_strategy {
@@ -218,6 +243,11 @@ resource "aws_ecs_service" "telemetry" {
   task_definition        = aws_ecs_task_definition.retool_telemetry[0].arn
   propagate_tags         = var.task_propagate_tags
   enable_execute_command = var.enable_execute_command
+
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
 
   # Need to explictly set this in aws_ecs_service to avoid destructive behavior: https://github.com/hashicorp/terraform-provider-aws/issues/22823
   capacity_provider_strategy {


### PR DESCRIPTION
…vices

Enable ECS deployment circuit breaker with automatic rollback on all 6 Retool ECS services. Add CloudWatch event rules and metric alarms to detect deployment failures and notify via the prod platform SNS topic.

Closes PLA-2152